### PR TITLE
Classify errors; userError vs servicefault

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -1,4 +1,4 @@
-package prbot
+package errors
 
 import (
 	"context"
@@ -26,6 +26,14 @@ func (e APIError) Error() string {
 func (e APIError) Render(_ http.ResponseWriter, r *http.Request) error {
 	render.Status(r, e.StatusCode)
 	return nil
+}
+
+func (e APIError) IsUserError() bool {
+	return e.StatusCode >= 400 && e.StatusCode < 500
+}
+
+func (e APIError) IsServiceError() bool {
+	return !e.IsUserError()
 }
 
 func RenderError(w http.ResponseWriter, r *http.Request, err error) {

--- a/github/api.go
+++ b/github/api.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/google/go-github/v50/github"
-	prbot "github.com/marqeta/pr-bot"
+	pe "github.com/marqeta/pr-bot/errors"
 	"github.com/marqeta/pr-bot/id"
 	"github.com/shurcooL/githubv4"
 )
@@ -47,7 +47,7 @@ type API interface {
 	AddReview(ctx context.Context, id id.PR, summary, event string) error
 	EnableAutoMerge(ctx context.Context, id id.PR, method githubv4.PullRequestMergeMethod) error
 	IssueComment(ctx context.Context, id id.PR, comment string) error
-	IssueCommentForError(ctx context.Context, id id.PR, err prbot.APIError) error
+	IssueCommentForError(ctx context.Context, id id.PR, err pe.APIError) error
 	ListAllTopics(ctx context.Context, id id.PR) ([]string, error)
 	ListRequiredStatusChecks(ctx context.Context, id id.PR, branch string) ([]string, error)
 	ListFilesInRootDir(ctx context.Context, id id.PR, branch string) ([]string, error)

--- a/github/mock_api.go
+++ b/github/mock_api.go
@@ -5,12 +5,12 @@ package github
 import (
 	context "context"
 
-	id "github.com/marqeta/pr-bot/id"
+	errors "github.com/marqeta/pr-bot/errors"
 	githubv4 "github.com/shurcooL/githubv4"
 
-	mock "github.com/stretchr/testify/mock"
+	id "github.com/marqeta/pr-bot/id"
 
-	prbot "github.com/marqeta/pr-bot"
+	mock "github.com/stretchr/testify/mock"
 
 	v50github "github.com/google/go-github/v50/github"
 )
@@ -218,11 +218,11 @@ func (_c *MockAPI_IssueComment_Call) RunAndReturn(run func(context.Context, id.P
 }
 
 // IssueCommentForError provides a mock function with given fields: ctx, _a1, err
-func (_m *MockAPI) IssueCommentForError(ctx context.Context, _a1 id.PR, err prbot.APIError) error {
+func (_m *MockAPI) IssueCommentForError(ctx context.Context, _a1 id.PR, err errors.APIError) error {
 	ret := _m.Called(ctx, _a1, err)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, id.PR, prbot.APIError) error); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, id.PR, errors.APIError) error); ok {
 		r0 = rf(ctx, _a1, err)
 	} else {
 		r0 = ret.Error(0)
@@ -239,14 +239,14 @@ type MockAPI_IssueCommentForError_Call struct {
 // IssueCommentForError is a helper method to define mock.On call
 //   - ctx context.Context
 //   - _a1 id.PR
-//   - err prbot.APIError
+//   - err errors.APIError
 func (_e *MockAPI_Expecter) IssueCommentForError(ctx interface{}, _a1 interface{}, err interface{}) *MockAPI_IssueCommentForError_Call {
 	return &MockAPI_IssueCommentForError_Call{Call: _e.mock.On("IssueCommentForError", ctx, _a1, err)}
 }
 
-func (_c *MockAPI_IssueCommentForError_Call) Run(run func(ctx context.Context, _a1 id.PR, err prbot.APIError)) *MockAPI_IssueCommentForError_Call {
+func (_c *MockAPI_IssueCommentForError_Call) Run(run func(ctx context.Context, _a1 id.PR, err errors.APIError)) *MockAPI_IssueCommentForError_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(id.PR), args[2].(prbot.APIError))
+		run(args[0].(context.Context), args[1].(id.PR), args[2].(errors.APIError))
 	})
 	return _c
 }
@@ -256,7 +256,7 @@ func (_c *MockAPI_IssueCommentForError_Call) Return(_a0 error) *MockAPI_IssueCom
 	return _c
 }
 
-func (_c *MockAPI_IssueCommentForError_Call) RunAndReturn(run func(context.Context, id.PR, prbot.APIError) error) *MockAPI_IssueCommentForError_Call {
+func (_c *MockAPI_IssueCommentForError_Call) RunAndReturn(run func(context.Context, id.PR, errors.APIError) error) *MockAPI_IssueCommentForError_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pullrequest/dispatcher.go
+++ b/pullrequest/dispatcher.go
@@ -9,7 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/go-chi/httplog"
 	"github.com/google/go-github/v50/github"
-	prbot "github.com/marqeta/pr-bot"
+	pe "github.com/marqeta/pr-bot/errors"
 	"github.com/marqeta/pr-bot/id"
 	"github.com/marqeta/pr-bot/metrics"
 )
@@ -126,5 +126,5 @@ func (d *dispatcher) Dispatch(ctx context.Context, _ string, eventName string, e
 }
 
 func parseError(ctx context.Context, err error) error {
-	return prbot.InValidRequestError(ctx, "error parsing webhook event", err)
+	return pe.InValidRequestError(ctx, "error parsing webhook event", err)
 }

--- a/pullrequest/dispatcher_test.go
+++ b/pullrequest/dispatcher_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/google/go-github/v50/github"
-	prbot "github.com/marqeta/pr-bot"
+	pe "github.com/marqeta/pr-bot/errors"
 	"github.com/marqeta/pr-bot/id"
 	"github.com/marqeta/pr-bot/metrics"
 	"github.com/marqeta/pr-bot/pullrequest"
@@ -220,7 +220,7 @@ func Test_dispatcher_Dispatch(t *testing.T) {
 			setExpectations: func(_ id.PR, _ *github.PullRequestEvent,
 				_ *pullrequest.MockEventFilter, _ *pullrequest.MockEventHandler) {
 			},
-			wantErr: prbot.InValidRequestError(ctx, "error parsing webhook event", pullrequest.ErrMismatchedEvent),
+			wantErr: pe.InValidRequestError(ctx, "error parsing webhook event", pullrequest.ErrMismatchedEvent),
 		},
 		{
 			name: "Error when Event action is nil",
@@ -232,7 +232,7 @@ func Test_dispatcher_Dispatch(t *testing.T) {
 			setExpectations: func(_ id.PR, _ *github.PullRequestEvent,
 				_ *pullrequest.MockEventFilter, _ *pullrequest.MockEventHandler) {
 			},
-			wantErr: prbot.InValidRequestError(ctx, "error parsing webhook event", pullrequest.ErrEventActionNotFound),
+			wantErr: pe.InValidRequestError(ctx, "error parsing webhook event", pullrequest.ErrEventActionNotFound),
 		},
 		{
 			name: "Error when Event PR is nil",
@@ -247,7 +247,7 @@ func Test_dispatcher_Dispatch(t *testing.T) {
 			setExpectations: func(_ id.PR, _ *github.PullRequestEvent,
 				_ *pullrequest.MockEventFilter, _ *pullrequest.MockEventHandler) {
 			},
-			wantErr: prbot.InValidRequestError(ctx, "error parsing webhook event", pullrequest.ErrPRNotFound),
+			wantErr: pe.InValidRequestError(ctx, "error parsing webhook event", pullrequest.ErrPRNotFound),
 		},
 		{
 			name: "Should return error from event handler",

--- a/pullrequest/event_filter.go
+++ b/pullrequest/event_filter.go
@@ -5,8 +5,8 @@ import (
 	"regexp"
 
 	"github.com/go-chi/httplog"
-	prbot "github.com/marqeta/pr-bot"
 	"github.com/marqeta/pr-bot/configstore"
+	pe "github.com/marqeta/pr-bot/errors"
 	gh "github.com/marqeta/pr-bot/github"
 	"github.com/marqeta/pr-bot/id"
 )
@@ -106,7 +106,7 @@ func (f *repoFilter) ShouldHandle(ctx context.Context, id id.PR) (bool, error) {
 func (f *repoFilter) hasIgnoreTopic(ctx context.Context, id id.PR, cfg *RepoFilterCfg) (bool, error) {
 	topics, err := f.dao.ListAllTopics(ctx, id)
 	if err != nil {
-		return true, prbot.ServiceFault(ctx, "error listing topics on repo", err)
+		return true, pe.ServiceFault(ctx, "error listing topics on repo", err)
 	}
 	for _, topic := range topics {
 		if cfg.IgnoreTopicsMap[topic] {

--- a/pullrequest/review/dedup_reviewer.go
+++ b/pullrequest/review/dedup_reviewer.go
@@ -29,7 +29,7 @@ func (d *DedupReviewer) Approve(ctx context.Context, id id.PR, body string, opts
 		return err
 	}
 	if d.checkForReview(reviews, types.Approve) {
-		oplog.Info().Msgf("PR already has a review of type %v or higher", types.Approve)
+		oplog.Info().Msgf("PR already has a review of type %v or higher %v", types.Approve, id.URL)
 		return nil
 	}
 	return d.delegate.Approve(ctx, id, body, opts)
@@ -44,7 +44,7 @@ func (d *DedupReviewer) Comment(ctx context.Context, id id.PR, body string) erro
 		return err
 	}
 	if d.checkForReview(reviews, types.Comment) {
-		oplog.Info().Msgf("PR already has a review of type %v or higher", types.Comment)
+		oplog.Info().Msgf("PR already has a review of type %v or higher %v", types.Comment, id.URL)
 		return nil
 	}
 	return d.delegate.Comment(ctx, id, body)
@@ -59,7 +59,7 @@ func (d *DedupReviewer) RequestChanges(ctx context.Context, id id.PR, body strin
 		return err
 	}
 	if d.checkForReview(reviews, types.RequestChanges) {
-		oplog.Info().Msgf("PR already has a review of type %v or higher", types.RequestChanges)
+		oplog.Info().Msgf("PR already has a review of type %v or higher %v", types.RequestChanges, id.URL)
 		return nil
 	}
 	return d.delegate.RequestChanges(ctx, id, body)

--- a/pullrequest/review/rate_limited_reviewer.go
+++ b/pullrequest/review/rate_limited_reviewer.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 
 	"github.com/go-chi/httplog"
-	prbot "github.com/marqeta/pr-bot"
+	pe "github.com/marqeta/pr-bot/errors"
 	gh "github.com/marqeta/pr-bot/github"
 	"github.com/marqeta/pr-bot/id"
 	"github.com/marqeta/pr-bot/rate"
@@ -23,7 +23,7 @@ func (r *rateLimitedReviewer) Approve(ctx context.Context, id id.PR, body string
 	oplog := httplog.LogEntry(ctx)
 	err := r.throttler.ShouldThrottle(ctx, id)
 	if err != nil {
-		var ae prbot.APIError
+		var ae pe.APIError
 		if errors.As(err, &ae) && ae.StatusCode == http.StatusTooManyRequests {
 			oplog.Err(ae).Msgf("request throttled for PR %v", id.URL)
 			// TODO publish error in UI and/or as comments on PR

--- a/pullrequest/review/rate_limited_reviewer_test.go
+++ b/pullrequest/review/rate_limited_reviewer_test.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"testing"
 
-	prbot "github.com/marqeta/pr-bot"
+	pe "github.com/marqeta/pr-bot/errors"
 	gh "github.com/marqeta/pr-bot/github"
 	"github.com/marqeta/pr-bot/id"
 	"github.com/marqeta/pr-bot/pullrequest/review"
@@ -18,7 +18,7 @@ func Test_rateLimitedReviewer_Approve(t *testing.T) {
 	ctx := context.Background()
 	//nolint:goerr113
 	errRandom := errors.New("random error")
-	errThrottled := prbot.TooManyRequestError(ctx, "throttled", lim.ErrLimitExhausted)
+	errThrottled := pe.TooManyRequestError(ctx, "throttled", lim.ErrLimitExhausted)
 	type args struct {
 		id              id.PR
 		body            string

--- a/pullrequest/review/reviewer.go
+++ b/pullrequest/review/reviewer.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/go-chi/httplog"
-	prbot "github.com/marqeta/pr-bot"
+	pe "github.com/marqeta/pr-bot/errors"
 	gh "github.com/marqeta/pr-bot/github"
 	"github.com/marqeta/pr-bot/id"
 	"github.com/marqeta/pr-bot/metrics"
@@ -47,7 +47,7 @@ func (r *reviewer) Approve(ctx context.Context, id id.PR, body string, opts Appr
 	err = r.api.AddReview(ctx, id, body, gh.Approve)
 	if err != nil {
 		oplog.Err(err).Msgf("error approving PR")
-		ae := prbot.ServiceFault(ctx, "Error approving PR", err)
+		ae := pe.ServiceFault(ctx, "Error approving PR", err)
 		// TODO publish error in UI and/or as comments on PR
 		return ae
 	}
@@ -63,7 +63,7 @@ func (r *reviewer) Comment(ctx context.Context, id id.PR, body string) error {
 	err := r.api.AddReview(ctx, id, body, gh.Comment)
 	if err != nil {
 		oplog.Err(err).Msgf("error reviewing PR with reviewType:comment %v", id.URL)
-		ae := prbot.ServiceFault(ctx, "error reviewing PR with reviewType:comment", err)
+		ae := pe.ServiceFault(ctx, "error reviewing PR with reviewType:comment", err)
 		// TODO publish error in UI and/or as comments on PR
 		return ae
 	}
@@ -78,7 +78,7 @@ func (r *reviewer) RequestChanges(ctx context.Context, id id.PR, body string) er
 	err := r.api.AddReview(ctx, id, body, gh.RequestChanges)
 	if err != nil {
 		oplog.Err(err).Msgf("error reviewing PR with reviewType:changes_requested %v", id.URL)
-		ae := prbot.ServiceFault(ctx, "error reviewing PR with reviewType:changes_requested", err)
+		ae := pe.ServiceFault(ctx, "error reviewing PR with reviewType:changes_requested", err)
 		// TODO publish error in UI and/or as comments on PR
 		return ae
 	}
@@ -95,7 +95,7 @@ func NewReviewer(dao gh.API, metrics metrics.Emitter) Reviewer {
 func (r *reviewer) handleAutoMergeError(ctx context.Context, id id.PR, err error) error {
 	msg := strings.ToLower(err.Error())
 	if strings.Contains(msg, "pull request auto merge is not allowed") {
-		ae := prbot.UserError(ctx, AutoMergeError, err)
+		ae := pe.UserError(ctx, AutoMergeError, err)
 		r.metrics.EmitDist(ctx, "autoMergeDisabled", 1.0, id.ToTags())
 		// TODO publish error in UI and/or as comments on PR
 		return ae
@@ -103,12 +103,12 @@ func (r *reviewer) handleAutoMergeError(ctx context.Context, id id.PR, err error
 	if strings.Contains(msg, "pull request is in has_hooks status") ||
 		strings.Contains(msg, "pull request is in clean status") {
 		friendlyErr := fmt.Errorf("enable atleast one branch protection rule on the default branch : %w", err)
-		ae := prbot.UserError(ctx, AutoMergeError, friendlyErr)
+		ae := pe.UserError(ctx, AutoMergeError, friendlyErr)
 		r.metrics.EmitDist(ctx, "noBranchProtectionRules", 1.0, id.ToTags())
 		// TODO publish error in UI and/or as comments on PR
 		return ae
 	}
-	ae := prbot.ServiceFault(ctx, AutoMergeError, err)
+	ae := pe.ServiceFault(ctx, AutoMergeError, err)
 	// TODO publish error in UI and/or as comments on PR
 	return ae
 }

--- a/rate/sliding_window.go
+++ b/rate/sliding_window.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"fmt"
 
-	prbot "github.com/marqeta/pr-bot"
 	"github.com/marqeta/pr-bot/configstore"
+	pe "github.com/marqeta/pr-bot/errors"
 	"github.com/marqeta/pr-bot/id"
 	lim "github.com/mennanov/limiters"
 )
@@ -46,7 +46,7 @@ func (sw *swLimiter) ShouldThrottle(ctx context.Context, id id.PR) error {
 	if err != nil && errors.Is(err, lim.ErrLimitExhausted) {
 		// throttled
 		msg := fmt.Sprintf("%v throttled request for key %v, try again in %v", sw.Name(), sw.Key(id), waitTime)
-		return prbot.TooManyRequestError(ctx, msg, err)
+		return pe.TooManyRequestError(ctx, msg, err)
 	}
 	return err
 }

--- a/rate/sliding_window_test.go
+++ b/rate/sliding_window_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
-	prbot "github.com/marqeta/pr-bot"
 	"github.com/marqeta/pr-bot/configstore"
+	pe "github.com/marqeta/pr-bot/errors"
 	"github.com/marqeta/pr-bot/id"
 	"github.com/marqeta/pr-bot/rate"
 	"github.com/stretchr/testify/assert"
@@ -51,7 +51,7 @@ func Test_swLimiter_ShouldThrottle(t *testing.T) {
 			args: args{
 				id: ID("owner1", "repo1", "author1"),
 			},
-			wantErr: prbot.TooManyRequestError(ctx,
+			wantErr: pe.TooManyRequestError(ctx,
 				fmt.Sprintf("%v throttled request for key %v, try again in %v",
 					"Mock", "Repo/owner1/repo1", 5*time.Second),
 				lim.ErrLimitExhausted),
@@ -73,7 +73,7 @@ func Test_swLimiter_ShouldThrottle(t *testing.T) {
 			args: args{
 				id: ID("owner1", "repo1", "author1"),
 			},
-			wantErr: prbot.TooManyRequestError(ctx,
+			wantErr: pe.TooManyRequestError(ctx,
 				fmt.Sprintf("%v throttled request for key %v, try again in %v",
 					"Mock", "Org/owner1", 5*time.Second),
 				lim.ErrLimitExhausted),
@@ -95,7 +95,7 @@ func Test_swLimiter_ShouldThrottle(t *testing.T) {
 			args: args{
 				id: ID("owner1", "repo1", "author1"),
 			},
-			wantErr: prbot.TooManyRequestError(ctx,
+			wantErr: pe.TooManyRequestError(ctx,
 				fmt.Sprintf("%v throttled request for key %v, try again in %v",
 					"Mock", "Author/author1", 5*time.Second),
 				lim.ErrLimitExhausted),

--- a/webhook/controller.go
+++ b/webhook/controller.go
@@ -8,7 +8,8 @@ import (
 	"github.com/go-chi/httplog"
 	"github.com/go-chi/render"
 	"github.com/google/go-github/v50/github"
-	prbot "github.com/marqeta/pr-bot"
+
+	pe "github.com/marqeta/pr-bot/errors"
 	"github.com/marqeta/pr-bot/opa/evaluation"
 )
 
@@ -32,8 +33,8 @@ func (c *controller) HandleEvent(w http.ResponseWriter, r *http.Request) {
 	payload, err := c.parser.ValidatePayload(r, []byte(c.webhookSecrect))
 	if err != nil {
 		oplog.Err(err).Msg("could not validate webhook payload")
-		prbot.RenderError(w, r,
-			prbot.InValidRequestError(ctx, "could not validate webhook payload", err))
+		pe.RenderError(w, r,
+			pe.InValidRequestError(ctx, "could not validate webhook payload", err))
 		return
 	}
 
@@ -41,8 +42,8 @@ func (c *controller) HandleEvent(w http.ResponseWriter, r *http.Request) {
 	event, err := c.parser.ParseWebHook(github.WebHookType(r), payload)
 	if err != nil {
 		oplog.Err(err).Msg("could not parse webhook")
-		prbot.RenderError(w, r,
-			prbot.InValidRequestError(ctx, "could not parse webhook", err))
+		pe.RenderError(w, r,
+			pe.InValidRequestError(ctx, "could not parse webhook", err))
 		return
 	}
 
@@ -65,7 +66,7 @@ func (c *controller) HandleEvent(w http.ResponseWriter, r *http.Request) {
 
 	if err != nil {
 		oplog.Err(err).Msg("Error Handling Event")
-		prbot.RenderError(w, r, err)
+		pe.RenderError(w, r, err)
 	} else {
 		_ = render.Render(w, r, &EventResponse{
 			StatusCode: http.StatusAccepted,


### PR DESCRIPTION
- Branch protection not enabled = userError
- Required status checks not enabled = userError
- Cannot acquire lock to add review = TooManyRequestError
- Increase lease duration to 25s, refresh to 5s and heartbeat to 4s

Refactored errors into a separate package to avoid import cycle