### PR TITLE
Use squash/merge method to commit empty PRs

### DIFF
--- a/pullrequest/dispatcher_test.go
+++ b/pullrequest/dispatcher_test.go
@@ -373,6 +373,11 @@ func sampleID() id.PR {
 	}
 }
 
+func empty(e *github.PullRequestEvent) *github.PullRequestEvent {
+	e.PullRequest.ChangedFiles = github.Int(0)
+	return e
+}
+
 func prEvent(action *string, id id.PR) *github.PullRequestEvent {
 	url := fmt.Sprintf("%s/%s/%d", id.Owner, id.Repo, id.Number)
 	return &github.PullRequestEvent{
@@ -392,6 +397,7 @@ func prEvent(action *string, id id.PR) *github.PullRequestEvent {
 					AllowMergeCommit: aws.Bool(false),
 				},
 			},
+			ChangedFiles: github.Int(1),
 		},
 		Repo: &github.Repository{
 			Owner: &github.User{
@@ -403,6 +409,14 @@ func prEvent(action *string, id id.PR) *github.PullRequestEvent {
 			Visibility:    github.String("public"),
 		},
 	}
+}
+
+func allMergeMethods(event *github.PullRequestEvent) *github.PullRequestEvent {
+	event.PullRequest.Base.Repo.AllowAutoMerge = aws.Bool(true)
+	event.PullRequest.Base.Repo.AllowMergeCommit = aws.Bool(true)
+	event.PullRequest.Base.Repo.AllowRebaseMerge = aws.Bool(true)
+	event.PullRequest.Base.Repo.AllowSquashMerge = aws.Bool(true)
+	return event
 }
 
 func merge(event *github.PullRequestEvent) *github.PullRequestEvent {

--- a/pullrequest/event_handler.go
+++ b/pullrequest/event_handler.go
@@ -71,8 +71,12 @@ func (eh *eventHandler) EvalAndReview(ctx context.Context, id id.PR, event *gith
 func mergeMethod(event *github.PullRequestEvent) githubv4.PullRequestMergeMethod {
 	rebase := event.PullRequest.GetBase().GetRepo().GetAllowRebaseMerge()
 	squash := event.PullRequest.GetBase().GetRepo().GetAllowSquashMerge()
-
-	if rebase {
+	fc := event.PullRequest.GetChangedFiles()
+	// TODO: let policy specify what merge method to use.
+	// when rebasing empty commits on to main,
+	// no new commit is created, therefore no triggers would be fired.
+	// use squash to force a new commit to be created. when merging empty PRs
+	if rebase && fc > 0 {
 		return githubv4.PullRequestMergeMethodRebase
 	}
 	if squash {

--- a/pullrequest/event_handler_test.go
+++ b/pullrequest/event_handler_test.go
@@ -116,6 +116,50 @@ func Test_eventHandlerV2_EvalAndReview(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "Should approve PRs with squash merge method for empty commits",
+			args: args{
+				id:    sampleID(),
+				event: empty(allMergeMethods(prEvent(github.String("opened"), sampleID()))),
+				setExpectaions: func(e *opa.MockEvaluator, r *review.MockReviewer, p *github.PullRequestEvent) {
+					e.EXPECT().Evaluate(ctx, ToGHE(p)).Return(types.Result{
+						Track: true,
+						Review: types.Review{
+							Type: types.Approve,
+							Body: "LGTM",
+						},
+					}, nil)
+					r.EXPECT().Approve(ctx, sampleID(), "LGTM", review.ApproveOptions{
+						AutoMergeEnabled: true,
+						DefaultBranch:    "main",
+						MergeMethod:      githubv4.PullRequestMergeMethodSquash,
+					}).Return(nil)
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Should approve PRs with merge commit for empty commits",
+			args: args{
+				id:    sampleID(),
+				event: empty(rebase(merge(prEvent(github.String("opened"), sampleID())))),
+				setExpectaions: func(e *opa.MockEvaluator, r *review.MockReviewer, p *github.PullRequestEvent) {
+					e.EXPECT().Evaluate(ctx, ToGHE(p)).Return(types.Result{
+						Track: true,
+						Review: types.Review{
+							Type: types.Approve,
+							Body: "LGTM",
+						},
+					}, nil)
+					r.EXPECT().Approve(ctx, sampleID(), "LGTM", review.ApproveOptions{
+						AutoMergeEnabled: true,
+						DefaultBranch:    "main",
+						MergeMethod:      githubv4.PullRequestMergeMethodMerge,
+					}).Return(nil)
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "Should approve PRs with squash merge method",
 			args: args{
 				id:    sampleID(),


### PR DESCRIPTION

	when rebasing empty commits on to main,
	 no new commit is created, therefore no triggers would be fired.
	 use squash to force a new commit to be created. when merging empty PRs