### PR TITLE
Get flags from repository field if it doesn't exist in pull-request

### DIFF
--- a/pullrequest/event_handler.go
+++ b/pullrequest/event_handler.go
@@ -101,8 +101,8 @@ func (eh *eventHandler) EvalAndReview(ctx context.Context, id id.PR, ghe input.G
 }
 
 func mergeMethod(ghe input.GHE) githubv4.PullRequestMergeMethod {
-	rebase := ghe.PullRequest.GetBase().GetRepo().GetAllowRebaseMerge()
-	squash := ghe.PullRequest.GetBase().GetRepo().GetAllowSquashMerge()
+	rebase := ghe.PullRequest.GetBase().GetRepo().GetAllowRebaseMerge() || ghe.Repository.GetAllowRebaseMerge()
+	squash := ghe.PullRequest.GetBase().GetRepo().GetAllowSquashMerge() || ghe.Repository.GetAllowSquashMerge()
 	fc := ghe.PullRequest.GetChangedFiles()
 	// TODO: let policy specify what merge method to use.
 	// when rebasing empty commits on to main,

--- a/pullrequest/event_handler_test.go
+++ b/pullrequest/event_handler_test.go
@@ -33,7 +33,8 @@ func Test_eventHandlerV2_EvalAndReview(t *testing.T) {
 				id:    sampleID(),
 				event: merge(prEvent(github.String("opened"), sampleID())),
 				setExpectaions: func(e *opa.MockEvaluator, r *review.MockReviewer, p *github.PullRequestEvent) {
-					p.PullRequest.Base.Repo.AllowAutoMerge = github.Bool(true)
+					p.GetPullRequest().Base.Repo.AllowAutoMerge = github.Bool(true)
+					p.GetRepo().AllowAutoMerge = nil
 
 					e.EXPECT().Evaluate(ctx, ToGHE(p)).Return(types.Result{
 						Track: true,
@@ -101,7 +102,10 @@ func Test_eventHandlerV2_EvalAndReview(t *testing.T) {
 				id:    sampleID(),
 				event: rebase(prEvent(github.String("opened"), sampleID())),
 				setExpectaions: func(e *opa.MockEvaluator, r *review.MockReviewer, p *github.PullRequestEvent) {
-					p.Repo.AllowRebaseMerge = github.Bool(true)
+					p.GetPullRequest().Base.Repo.AllowRebaseMerge = nil
+					p.GetRepo().AllowRebaseMerge = github.Bool(true)
+					p.GetRepo().AllowAutoMerge = github.Bool(true)
+
 					e.EXPECT().Evaluate(ctx, ToGHE(p)).Return(types.Result{
 						Track: true,
 						Review: types.Review{
@@ -261,7 +265,7 @@ func Test_eventHandlerV2_EvalAndReview(t *testing.T) {
 				id:    sampleID(),
 				event: prEvent(github.String("opened"), sampleID()),
 				setExpectaions: func(e *opa.MockEvaluator, r *review.MockReviewer, p *github.PullRequestEvent) {
-					p.PullRequest.Base.Repo.AllowAutoMerge = github.Bool(false)
+					p.GetPullRequest().Base.Repo.AllowAutoMerge = nil
 					e.EXPECT().Evaluate(ctx, ToGHE(p)).Return(types.Result{
 						Track: true,
 						Review: types.Review{


### PR DESCRIPTION
The data that is received from Github Webhook events are different from fetching the data via the API. Due to this discrepancy, we should conditionally get the data from the pull request or the repository field. 
