### PR TITLE
Add verification of sigv4 for the endpoint

### DIFF
--- a/config.go
+++ b/config.go
@@ -71,6 +71,10 @@ type Config struct {
 		Table string        `yaml:"Table" env:"TABLE"`
 		TTL   time.Duration `yaml:"TTL" env:"TTL"`
 	} `yaml:"Datastore" env-prefix:"DATASTORE_"`
+	Identity struct {
+		AllowedCallerArns     []string `yaml:"AllowedCallerArns" env:"ALLOWED_CALLER_ARNS"`
+		AllowedCallerAccounts []string `yaml:"AllowedCallerAccounts" env:"ALLOWED_CALLER_ACCOUNTS"`
+	} `yaml:"Identity" env-prefix:"IDENTITY_"`
 }
 
 func ParseConfigFiles() (*Config, error) {

--- a/config/local.yaml
+++ b/config/local.yaml
@@ -15,7 +15,7 @@ Throttler:
   TTLFieldName: "ttl"
 OPA:
   Bundles:
-    Root: "/Users/pkrishnan/ws/pr-bot/bundles"
+    Root: "/Users/jamirkulov/ws/pr-bot/bundles"
     Filename: "pr-bot-policy-dev.tar.gz"
     ECR:
       Registry: "986695000930.dkr.ecr.us-east-1.amazonaws.com"
@@ -30,3 +30,8 @@ Reviewer:
 Datastore:
   Table: "pr-bot-dev-datastore"
   TTL: 336h
+Identity:
+  AllowedCallerArns:
+    - "some-fake-arn"
+  AllowedCallerAccounts:
+    - "0000000000"

--- a/data/controller.go
+++ b/data/controller.go
@@ -32,7 +32,7 @@ type GetCallerIdentityResponse struct {
 	} `xml:"GetCallerIdentityResult"`
 }
 
-var HttpGet = http.Get
+var HTTPGet = http.Get
 
 func (e *Response) Render(_ http.ResponseWriter, r *http.Request) error {
 	render.Status(r, e.StatusCode)
@@ -96,7 +96,7 @@ func verifySTSIdentity(ctx context.Context, r *http.Request) (string, error) {
 		return "", pe.UserError(ctx, "missing STS signature header", nil)
 	}
 
-	resp, err := HttpGet(stsURL)
+	resp, err := HTTPGet(stsURL)
 	if err != nil {
 		return "", pe.UserError(ctx, "failed to call STS", err)
 	}
@@ -107,6 +107,7 @@ func verifySTSIdentity(ctx context.Context, r *http.Request) (string, error) {
 	oplog.Info().Int("status", resp.StatusCode).Str("url", stsURL).Msg("STS GetCallerIdentity response")
 
 	if resp.StatusCode != http.StatusOK {
+		//nolint:goerr113
 		return "", pe.UserError(ctx, "STS responded with non-200", errors.New("non-200 response from STS"))
 	}
 
@@ -126,6 +127,7 @@ func verifySTSIdentity(ctx context.Context, r *http.Request) (string, error) {
 	oplog.Info().Str("callerarn", callerArn).Msg("STS CALLER ARN")
 
 	if callerArn == "" || !strings.Contains(callerArn, ":assumed-role/s--polynator") {
+		//nolint:goerr113
 		return "", pe.UserError(ctx, "unauthorized identity", errors.New("unauthorized identity"))
 	}
 

--- a/data/controller.go
+++ b/data/controller.go
@@ -1,15 +1,10 @@
 package data
 
 import (
-	"context"
-	"encoding/xml"
-	"errors"
-	"io"
-	"net/http"
-	"strings"
-
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/google/uuid"
+	"io"
+	"net/http"
 
 	"github.com/go-chi/httplog"
 	"github.com/go-chi/render"
@@ -23,17 +18,6 @@ type Response struct {
 	Message    string `json:"message,omitempty"`
 }
 
-type GetCallerIdentityResponse struct {
-	XMLName xml.Name `xml:"GetCallerIdentityResponse"`
-	Result  struct {
-		Arn     string `xml:"Arn"`
-		Account string `xml:"Account"`
-		UserID  string `xml:"UserId"`
-	} `xml:"GetCallerIdentityResult"`
-}
-
-var HTTPGet = http.Get
-
 func (e *Response) Render(_ http.ResponseWriter, r *http.Request) error {
 	render.Status(r, e.StatusCode)
 	return nil
@@ -45,14 +29,14 @@ func (c *controller) HandleEvent(w http.ResponseWriter, r *http.Request) {
 	ctx = evaluation.SetDeliveryID(r.Context(), uuid.NewString())
 	oplog := httplog.LogEntry(ctx)
 
-	callerArn, err := verifySTSIdentity(ctx, r)
+	callerArn, err := c.verifier.Verify(ctx, r)
 	if err != nil {
 		oplog.Err(err).Msg("identity verification failed")
 		pe.RenderError(w, r, err)
 		return
 	}
 
-	oplog.Info().Str("callerArn", callerArn).Msg("identity verified")
+	oplog.Info().Str("sigv4 callerArn", callerArn).Msg("identity verified")
 
 	metadata, err := c.dao.ToMetadata(ctx, r)
 	if err != nil {
@@ -88,46 +72,4 @@ func (c *controller) HandleEvent(w http.ResponseWriter, r *http.Request) {
 		RequestID:  reqID,
 		Message:    "payload stored successfully",
 	})
-}
-
-func verifySTSIdentity(ctx context.Context, r *http.Request) (string, error) {
-	stsURL := r.Header.Get("X-Aws-Sts-Signature")
-	if stsURL == "" {
-		return "", pe.UserError(ctx, "missing STS signature header", nil)
-	}
-
-	resp, err := HTTPGet(stsURL)
-	if err != nil {
-		return "", pe.UserError(ctx, "failed to call STS", err)
-	}
-	defer resp.Body.Close()
-
-	oplog := httplog.LogEntry(ctx)
-
-	oplog.Info().Int("status", resp.StatusCode).Str("url", stsURL).Msg("STS GetCallerIdentity response")
-
-	if resp.StatusCode != http.StatusOK {
-		//nolint:goerr113
-		return "", pe.UserError(ctx, "STS responded with non-200", errors.New("non-200 response from STS"))
-	}
-
-	stsBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return "", pe.UserError(ctx, "STS read error", err)
-	}
-
-	var stsResp GetCallerIdentityResponse
-	if err := xml.Unmarshal(stsBody, &stsResp); err != nil {
-		return "", pe.UserError(ctx, "STS parse error", err)
-	}
-
-	callerArn := stsResp.Result.Arn
-	oplog.Info().Str("callerarn", callerArn).Msg("STS CALLER ARN")
-
-	if callerArn == "" || !strings.Contains(callerArn, ":assumed-role/s--polynator") {
-		//nolint:goerr113
-		return "", pe.UserError(ctx, "unauthorized identity", errors.New("unauthorized identity"))
-	}
-
-	return callerArn, nil
 }

--- a/data/controller.go
+++ b/data/controller.go
@@ -1,8 +1,12 @@
 package data
 
 import (
+	"context"
+	"encoding/xml"
+	"errors"
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/google/uuid"
@@ -19,6 +23,17 @@ type Response struct {
 	Message    string `json:"message,omitempty"`
 }
 
+type GetCallerIdentityResponse struct {
+	XMLName xml.Name `xml:"GetCallerIdentityResponse"`
+	Result  struct {
+		Arn     string `xml:"Arn"`
+		Account string `xml:"Account"`
+		UserID  string `xml:"UserId"`
+	} `xml:"GetCallerIdentityResult"`
+}
+
+var HttpGet = http.Get
+
 func (e *Response) Render(_ http.ResponseWriter, r *http.Request) error {
 	render.Status(r, e.StatusCode)
 	return nil
@@ -30,8 +45,15 @@ func (c *controller) HandleEvent(w http.ResponseWriter, r *http.Request) {
 	ctx = evaluation.SetDeliveryID(r.Context(), uuid.NewString())
 	oplog := httplog.LogEntry(ctx)
 
-	// do auth verification
-	// TODO SigV4 verification for presigned get-caller-identity request
+	callerArn, err := verifySTSIdentity(ctx, r)
+	if err != nil {
+		oplog.Err(err).Msg("identity verification failed")
+		pe.RenderError(w, r, err)
+		return
+	}
+
+	oplog.Info().Str("callerArn", callerArn).Msg("identity verified")
+
 	metadata, err := c.dao.ToMetadata(ctx, r)
 	if err != nil {
 		oplog.Err(err).Msg("error parsing metadata")
@@ -56,14 +78,56 @@ func (c *controller) HandleEvent(w http.ResponseWriter, r *http.Request) {
 
 	err = c.handler.EvalAndReviewDataEvent(ctx, metadata)
 	if err != nil {
-		// handle evaluation error
-		oplog.Err(err).Msg("error evaluating polciies during data event")
+		oplog.Err(err).Msg("error evaluating policies during data event")
 		pe.RenderError(w, r, err)
 		return
 	}
+
 	_ = render.Render(w, r, &Response{
 		StatusCode: http.StatusOK,
 		RequestID:  reqID,
 		Message:    "payload stored successfully",
 	})
+}
+
+func verifySTSIdentity(ctx context.Context, r *http.Request) (string, error) {
+	stsURL := r.Header.Get("X-Aws-Sts-Signature")
+	if stsURL == "" {
+		return "", pe.UserError(ctx, "missing STS signature header", nil)
+	}
+
+	resp, err := HttpGet(stsURL)
+	if err != nil {
+		return "", pe.UserError(ctx, "failed to call STS", err)
+	}
+	defer resp.Body.Close()
+
+	oplog := httplog.LogEntry(ctx)
+
+	oplog.Info().Int("status", resp.StatusCode).Str("url", stsURL).Msg("STS GetCallerIdentity response")
+
+	if resp.StatusCode != http.StatusOK {
+		return "", pe.UserError(ctx, "STS responded with non-200", errors.New("non-200 response from STS"))
+	}
+
+	// Log the actual status code
+
+	stsBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", pe.UserError(ctx, "STS read error", err)
+	}
+
+	var stsResp GetCallerIdentityResponse
+	if err := xml.Unmarshal(stsBody, &stsResp); err != nil {
+		return "", pe.UserError(ctx, "STS parse error", err)
+	}
+
+	callerArn := stsResp.Result.Arn
+	oplog.Info().Str("callerarn", callerArn).Msg("STS CALLER ARN")
+
+	if callerArn == "" || !strings.Contains(callerArn, ":assumed-role/s--polynator") {
+		return "", pe.UserError(ctx, "unauthorized identity", errors.New("unauthorized identity"))
+	}
+
+	return callerArn, nil
 }

--- a/data/controller.go
+++ b/data/controller.go
@@ -1,13 +1,13 @@
 package data
 
 import (
-	"github.com/go-chi/chi/v5/middleware"
-	"github.com/google/uuid"
 	"io"
 	"net/http"
-	//nolint:err113
+
+	"github.com/go-chi/chi/v5/middleware"
+	"github.com/google/uuid"
+
 	"github.com/go-chi/httplog"
-	//nolint:err113
 	"github.com/go-chi/render"
 	pe "github.com/marqeta/pr-bot/errors"
 	"github.com/marqeta/pr-bot/opa/evaluation"

--- a/data/controller.go
+++ b/data/controller.go
@@ -111,8 +111,6 @@ func verifySTSIdentity(ctx context.Context, r *http.Request) (string, error) {
 		return "", pe.UserError(ctx, "STS responded with non-200", errors.New("non-200 response from STS"))
 	}
 
-	// Log the actual status code
-
 	stsBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", pe.UserError(ctx, "STS read error", err)

--- a/data/controller.go
+++ b/data/controller.go
@@ -5,8 +5,9 @@ import (
 	"github.com/google/uuid"
 	"io"
 	"net/http"
-
+	//nolint:err113
 	"github.com/go-chi/httplog"
+	//nolint:err113
 	"github.com/go-chi/render"
 	pe "github.com/marqeta/pr-bot/errors"
 	"github.com/marqeta/pr-bot/opa/evaluation"

--- a/data/controller_test.go
+++ b/data/controller_test.go
@@ -35,10 +35,11 @@ func Test_controller_HandleEvent(t *testing.T) {
 		</GetCallerIdentityResult>
 	</GetCallerIdentityResponse>`
 
-	// Save and restore original HttpGet after test
-	originalHTTPGet := data.HttpGet
-	defer func() { data.HttpGet = originalHTTPGet }()
+	// Save and restore original HTTPGet after test
+	originalHTTPGet := data.HTTPGet
+	defer func() { data.HTTPGet = originalHTTPGet }()
 
+	//nolint:goerr113
 	randomErr := fmt.Errorf("random error")
 	payload := []byte(`{"key": "value"}`)
 	userErr := pe.UserError(context.TODO(), "error storing payload", randomErr)
@@ -125,7 +126,7 @@ func Test_controller_HandleEvent(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			data.HttpGet = func(url string) (*http.Response, error) {
+			data.HTTPGet = func(_ string) (*http.Response, error) {
 				return tt.stsResponse, tt.stsError
 			}
 

--- a/data/controller_test.go
+++ b/data/controller_test.go
@@ -25,12 +25,12 @@ import (
 )
 
 type mockVerifier struct {
-	identity.IdentityVerifier
+	identity.Verifier
 	Arn string
 	Err error
 }
 
-func (m *mockVerifier) Verify(ctx context.Context, r *http.Request) (string, error) {
+func (m *mockVerifier) Verify(_ context.Context, _ *http.Request) (string, error) {
 	return m.Arn, m.Err
 }
 

--- a/data/controller_test.go
+++ b/data/controller_test.go
@@ -5,40 +5,36 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 
-	"github.com/go-chi/chi/v5/middleware"
-
 	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
 	prbot "github.com/marqeta/pr-bot"
 	"github.com/marqeta/pr-bot/data"
 	store "github.com/marqeta/pr-bot/datastore"
 	pe "github.com/marqeta/pr-bot/errors"
 	"github.com/marqeta/pr-bot/id"
+	"github.com/marqeta/pr-bot/identity"
 	"github.com/marqeta/pr-bot/metrics"
 	pr "github.com/marqeta/pr-bot/pullrequest"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 )
 
+type mockVerifier struct {
+	identity.IdentityVerifier
+	Arn string
+	Err error
+}
+
+func (m *mockVerifier) Verify(ctx context.Context, r *http.Request) (string, error) {
+	return m.Arn, m.Err
+}
+
 func Test_controller_HandleEvent(t *testing.T) {
-	// Stub for STS GetCallerIdentity XML response
-	validSTSXML := `<GetCallerIdentityResponse>
-		<GetCallerIdentityResult>
-			<Arn>arn:aws:sts::123456789012:assumed-role/s--polynator/some-session</Arn>
-			<Account>123456789012</Account>
-			<UserId>some-user</UserId>
-		</GetCallerIdentityResult>
-	</GetCallerIdentityResponse>`
-
-	// Save and restore original HTTPGet after test
-	originalHTTPGet := data.HTTPGet
-	defer func() { data.HTTPGet = originalHTTPGet }()
-
 	//nolint:goerr113
 	randomErr := fmt.Errorf("random error")
 	payload := []byte(`{"key": "value"}`)
@@ -48,8 +44,6 @@ func Test_controller_HandleEvent(t *testing.T) {
 	tests := []struct {
 		name            string
 		setExpectations func(dao *store.MockDao, req *http.Request, eh *pr.MockEventHandler)
-		stsResponse     *http.Response
-		stsError        error
 		requestID       string
 		wantCode        int
 		wantMessage     string
@@ -59,13 +53,9 @@ func Test_controller_HandleEvent(t *testing.T) {
 			setExpectations: func(dao *store.MockDao, _ *http.Request, eh *pr.MockEventHandler) {
 				dao.EXPECT().ToMetadata(mock.Anything, mock.AnythingOfType("*http.Request")).
 					Return(randomMetadata(), nil).Once()
-				dao.EXPECT().StorePayload(mock.Anything, mock.Anything, json.RawMessage(payload)).
+				dao.EXPECT().StorePayload(mock.Anything, randomMetadata(), json.RawMessage(payload)).
 					Return(nil).Once()
-				eh.EXPECT().EvalAndReviewDataEvent(mock.Anything, mock.Anything).Return(nil).Once()
-			},
-			stsResponse: &http.Response{
-				StatusCode: 200,
-				Body:       io.NopCloser(strings.NewReader(validSTSXML)),
+				eh.EXPECT().EvalAndReviewDataEvent(mock.Anything, randomMetadata()).Return(nil).Once()
 			},
 			requestID:   "123A",
 			wantCode:    http.StatusOK,
@@ -77,27 +67,19 @@ func Test_controller_HandleEvent(t *testing.T) {
 				dao.EXPECT().ToMetadata(mock.Anything, mock.AnythingOfType("*http.Request")).
 					Return(nil, randomErr).Once()
 			},
-			stsResponse: &http.Response{
-				StatusCode: 200,
-				Body:       io.NopCloser(strings.NewReader(validSTSXML)),
-			},
 			requestID:   "123B",
 			wantCode:    http.StatusBadRequest,
 			wantMessage: "error parsing metadata",
 		},
 		{
-			name: "should return 400 when user error occurs while storing payload",
+			name: "should return 400 when user error occrs while storing payload",
 			setExpectations: func(dao *store.MockDao, _ *http.Request, _ *pr.MockEventHandler) {
 				err := userErr
 				err.RequestID = "123C"
 				dao.EXPECT().ToMetadata(mock.Anything, mock.AnythingOfType("*http.Request")).
 					Return(randomMetadata(), nil).Once()
-				dao.EXPECT().StorePayload(mock.Anything, mock.Anything, json.RawMessage(payload)).
+				dao.EXPECT().StorePayload(mock.Anything, randomMetadata(), json.RawMessage(payload)).
 					Return(err).Once()
-			},
-			stsResponse: &http.Response{
-				StatusCode: 200,
-				Body:       io.NopCloser(strings.NewReader(validSTSXML)),
 			},
 			requestID:   "123C",
 			wantCode:    http.StatusBadRequest,
@@ -110,41 +92,30 @@ func Test_controller_HandleEvent(t *testing.T) {
 				err.RequestID = "123D"
 				dao.EXPECT().ToMetadata(mock.Anything, mock.AnythingOfType("*http.Request")).
 					Return(randomMetadata(), nil).Once()
-				dao.EXPECT().StorePayload(mock.Anything, mock.Anything, json.RawMessage(payload)).
+				dao.EXPECT().StorePayload(mock.Anything, randomMetadata(), json.RawMessage(payload)).
 					Return(nil).Once()
-				eh.EXPECT().EvalAndReviewDataEvent(mock.Anything, mock.Anything).Return(err).Once()
-			},
-			stsResponse: &http.Response{
-				StatusCode: 200,
-				Body:       io.NopCloser(strings.NewReader(validSTSXML)),
+				eh.EXPECT().EvalAndReviewDataEvent(mock.Anything, randomMetadata()).Return(err).Once()
 			},
 			requestID:   "123D",
 			wantCode:    http.StatusInternalServerError,
 			wantMessage: "internal server error",
 		},
 	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			data.HTTPGet = func(_ string) (*http.Response, error) {
-				return tt.stsResponse, tt.stsError
-			}
-
 			dao := store.NewMockDao(t)
 			eh := pr.NewMockEventHandler(t)
-			e := data.NewEndpoint(dao, metrics.NewNoopEmitter(), eh)
+			verifier := &mockVerifier{Arn: "arn:aws:sts::123456789012:assumed-role/test-role/test-user"}
+			e := data.NewEndpoint(dao, metrics.NewNoopEmitter(), eh, verifier)
 
 			req := NewRequest(t, tt.requestID, randomMetadata(), payload)
-			req.Header.Set("X-Aws-Sts-Signature", "http://mock-sts-url") // Required for STS to work
-
 			tt.setExpectations(dao, req, eh)
 			res := executeRequest(req, e)
-
 			assert.Equal(t, tt.wantCode, res.Code)
 
 			var wantRes data.Response
 			err := json.Unmarshal(res.Body.Bytes(), &wantRes)
-			assert.Nil(t, err)
+			assert.Nil(t, err, "error when unmarshalling response")
 			assert.Equal(t, tt.requestID, wantRes.RequestID)
 			assert.Equal(t, tt.wantMessage, wantRes.Message)
 			assert.Equal(t, tt.wantCode, wantRes.StatusCode)

--- a/data/endpoint.go
+++ b/data/endpoint.go
@@ -4,6 +4,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	prbot "github.com/marqeta/pr-bot"
 	store "github.com/marqeta/pr-bot/datastore"
+	"github.com/marqeta/pr-bot/identity"
 	"github.com/marqeta/pr-bot/metrics"
 	"github.com/marqeta/pr-bot/pullrequest"
 	"github.com/slok/go-http-metrics/middleware"
@@ -15,17 +16,19 @@ type endpoint struct {
 }
 
 type controller struct {
-	metrics metrics.Emitter
-	dao     store.Dao
-	handler pullrequest.EventHandler
+	metrics  metrics.Emitter
+	dao      store.Dao
+	handler  pullrequest.EventHandler
+	verifier identity.IdentityVerifier
 }
 
-func NewEndpoint(d store.Dao, m metrics.Emitter, h pullrequest.EventHandler) prbot.Endpoint {
+func NewEndpoint(d store.Dao, m metrics.Emitter, h pullrequest.EventHandler, v identity.IdentityVerifier) prbot.Endpoint {
 	return &endpoint{
 		controller: &controller{
-			metrics: m,
-			dao:     d,
-			handler: h,
+			metrics:  m,
+			dao:      d,
+			handler:  h,
+			verifier: v,
 		},
 	}
 }

--- a/data/endpoint.go
+++ b/data/endpoint.go
@@ -19,10 +19,10 @@ type controller struct {
 	metrics  metrics.Emitter
 	dao      store.Dao
 	handler  pullrequest.EventHandler
-	verifier identity.IdentityVerifier
+	verifier identity.Verifier
 }
 
-func NewEndpoint(d store.Dao, m metrics.Emitter, h pullrequest.EventHandler, v identity.IdentityVerifier) prbot.Endpoint {
+func NewEndpoint(d store.Dao, m metrics.Emitter, h pullrequest.EventHandler, v identity.Verifier) prbot.Endpoint {
 	return &endpoint{
 		controller: &controller{
 			metrics:  m,

--- a/identity/fetcher.go
+++ b/identity/fetcher.go
@@ -13,7 +13,7 @@ import (
 	"net/url"
 )
 
-type IdentityFetcher interface {
+type Fetcher interface {
 	FetchCallerIdentity(ctx context.Context, r *http.Request) (*CallerIdentity, error)
 }
 
@@ -25,6 +25,7 @@ func (f *DefaultFetcher) FetchCallerIdentity(ctx context.Context, r *http.Reques
 	oplog := httplog.LogEntry(ctx)
 	rawPresignedURL := r.Header.Get("X-AWS-STS-SIGNATURE")
 	if rawPresignedURL == "" {
+		//nolint:goerr113
 		return nil, pe.UserError(ctx, "missing STS signature header", errors.New("no signature provided"))
 	}
 
@@ -54,6 +55,7 @@ func (f *DefaultFetcher) FetchCallerIdentity(ctx context.Context, r *http.Reques
 	oplog.Info().Int("status", resp.StatusCode).Str("url", secureSTSURL.String()).Msg("STS GetCallerIdentity response")
 
 	if resp.StatusCode != http.StatusOK {
+		//nolint:goerr113
 		return nil, pe.UserError(ctx, "STS responded with non-200", errors.New("non-200 response from STS"))
 	}
 

--- a/identity/fetcher.go
+++ b/identity/fetcher.go
@@ -2,16 +2,15 @@ package identity
 
 import (
 	"context"
-
 	"encoding/json"
 	"errors"
 	"fmt"
-	//nolint:err113
-	"github.com/go-chi/httplog"
-	pe "github.com/marqeta/pr-bot/errors"
 	"io"
 	"net/http"
 	"net/url"
+
+	"github.com/go-chi/httplog"
+	pe "github.com/marqeta/pr-bot/errors"
 )
 
 type Fetcher interface {

--- a/identity/fetcher.go
+++ b/identity/fetcher.go
@@ -21,7 +21,6 @@ type DefaultFetcher struct {
 	HTTPClient *http.Client
 }
 
-
 func (f *DefaultFetcher) FetchCallerIdentity(ctx context.Context, r *http.Request) (*CallerIdentity, error) {
 	oplog := httplog.LogEntry(ctx)
 	rawPresignedURL := r.Header.Get("X-AWS-STS-SIGNATURE")

--- a/identity/fetcher.go
+++ b/identity/fetcher.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	//nolint:err113
 	"github.com/go-chi/httplog"
 	pe "github.com/marqeta/pr-bot/errors"
 	"io"

--- a/identity/fetcher.go
+++ b/identity/fetcher.go
@@ -1,0 +1,73 @@
+package identity
+
+import (
+	"context"
+
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/go-chi/httplog"
+	pe "github.com/marqeta/pr-bot/errors"
+	"io"
+	"net/http"
+	"net/url"
+)
+
+type IdentityFetcher interface {
+	FetchCallerIdentity(ctx context.Context, r *http.Request) (*CallerIdentity, error)
+}
+
+type DefaultFetcher struct {
+	HTTPClient *http.Client
+}
+
+
+func (f *DefaultFetcher) FetchCallerIdentity(ctx context.Context, r *http.Request) (*CallerIdentity, error) {
+	oplog := httplog.LogEntry(ctx)
+	rawPresignedURL := r.Header.Get("X-AWS-STS-SIGNATURE")
+	if rawPresignedURL == "" {
+		return nil, pe.UserError(ctx, "missing STS signature header", errors.New("no signature provided"))
+	}
+
+	parsedURL, err := url.Parse(rawPresignedURL)
+	if err != nil {
+		return nil, pe.UserError(ctx, "invalid STS presigned URL", err)
+	}
+
+	reconstructedURL := fmt.Sprintf("https://sts.amazonaws.com/?%s", parsedURL.RawQuery)
+	secureSTSURL, err := url.Parse(reconstructedURL)
+	if err != nil {
+		return nil, pe.UserError(ctx, "could not build secure STS URL", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "GET", secureSTSURL.String(), nil)
+	if err != nil {
+		return nil, pe.UserError(ctx, "failed to construct STS request", err)
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := f.HTTPClient.Do(req)
+	if err != nil {
+		return nil, pe.UserError(ctx, "failed to call STS", err)
+	}
+	defer resp.Body.Close()
+
+	oplog.Info().Int("status", resp.StatusCode).Str("url", secureSTSURL.String()).Msg("STS GetCallerIdentity response")
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, pe.UserError(ctx, "STS responded with non-200", errors.New("non-200 response from STS"))
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, pe.UserError(ctx, "STS read error", err)
+	}
+	oplog.Info().Str("raw_sts_body", string(body)).Msg("STS raw response")
+
+	var jsonResp GetCallerIdentityJSON
+	if err := json.Unmarshal(body, &jsonResp); err != nil {
+		return nil, pe.UserError(ctx, "STS JSON parse error", err)
+	}
+
+	return &jsonResp.GetCallerIdentityResponse.GetCallerIdentityResult, nil
+}

--- a/identity/fetcher_test.go
+++ b/identity/fetcher_test.go
@@ -34,12 +34,12 @@ func TestFetchCallerIdentity(t *testing.T) {
 	}`
 
 	tests := []struct {
-		name               string
-		sigHeader          string
-		mockResponse       *http.Response
-		mockError          error
-		expectedErr        string
-		expectedCallerArn  string
+		name              string
+		sigHeader         string
+		mockResponse      *http.Response
+		mockError         error
+		expectedErr       string
+		expectedCallerArn string
 	}{
 		{
 			name:        "missing signature header",

--- a/identity/fetcher_test.go
+++ b/identity/fetcher_test.go
@@ -52,8 +52,9 @@ func TestFetchCallerIdentity(t *testing.T) {
 			expectedErr: "invalid STS presigned URL",
 		},
 		{
-			name:        "error calling STS",
-			sigHeader:   "Action=GetCallerIdentity&Version=2011-06-15",
+			name:      "error calling STS",
+			sigHeader: "Action=GetCallerIdentity&Version=2011-06-15",
+			//nolint:goerr113
 			mockError:   errors.New("http client error"),
 			expectedErr: "failed to call STS",
 		},
@@ -89,7 +90,7 @@ func TestFetchCallerIdentity(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mockTransport := &mockRoundTripper{
-				roundTripFunc: func(req *http.Request) (*http.Response, error) {
+				roundTripFunc: func(_ *http.Request) (*http.Response, error) {
 					return tt.mockResponse, tt.mockError
 				},
 			}

--- a/identity/fetcher_test.go
+++ b/identity/fetcher_test.go
@@ -1,0 +1,118 @@
+package identity_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/marqeta/pr-bot/identity"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockRoundTripper struct {
+	roundTripFunc func(*http.Request) (*http.Response, error)
+}
+
+func (m *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return m.roundTripFunc(req)
+}
+
+func TestFetchCallerIdentity(t *testing.T) {
+	validSTSResponse := `{
+		"GetCallerIdentityResponse": {
+			"GetCallerIdentityResult": {
+				"Arn": "arn:aws:sts::123456789012:assumed-role/MyRoleName/MySessionName",
+				"Account": "123456789012",
+				"UserId": "AIDABCDEFGHIJKL12345"
+			}
+		}
+	}`
+
+	tests := []struct {
+		name               string
+		sigHeader          string
+		mockResponse       *http.Response
+		mockError          error
+		expectedErr        string
+		expectedCallerArn  string
+	}{
+		{
+			name:        "missing signature header",
+			sigHeader:   "",
+			expectedErr: "missing STS signature header",
+		},
+		{
+			name:        "invalid presigned URL",
+			sigHeader:   ":::invalid-url:::",
+			expectedErr: "invalid STS presigned URL",
+		},
+		{
+			name:        "error calling STS",
+			sigHeader:   "Action=GetCallerIdentity&Version=2011-06-15",
+			mockError:   errors.New("http client error"),
+			expectedErr: "failed to call STS",
+		},
+		{
+			name:      "non-200 STS response",
+			sigHeader: "Action=GetCallerIdentity&Version=2011-06-15",
+			mockResponse: &http.Response{
+				StatusCode: 403,
+				Body:       io.NopCloser(strings.NewReader("Forbidden")),
+			},
+			expectedErr: "STS responded with non-200",
+		},
+		{
+			name:      "malformed JSON response",
+			sigHeader: "Action=GetCallerIdentity&Version=2011-06-15",
+			mockResponse: &http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(strings.NewReader("{not-json")),
+			},
+			expectedErr: "STS JSON parse error",
+		},
+		{
+			name:      "valid STS response",
+			sigHeader: "Action=GetCallerIdentity&Version=2011-06-15",
+			mockResponse: &http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(bytes.NewReader([]byte(validSTSResponse))),
+			},
+			expectedCallerArn: "arn:aws:sts::123456789012:assumed-role/MyRoleName/MySessionName",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockTransport := &mockRoundTripper{
+				roundTripFunc: func(req *http.Request) (*http.Response, error) {
+					return tt.mockResponse, tt.mockError
+				},
+			}
+			client := &http.Client{Transport: mockTransport}
+			fetcher := &identity.DefaultFetcher{
+				HTTPClient: client,
+			}
+
+			req := httptest.NewRequest("GET", "/", nil)
+			if tt.sigHeader != "" {
+				req.Header.Set("X-AWS-STS-SIGNATURE", tt.sigHeader)
+			}
+
+			ctx := context.Background()
+			caller, err := fetcher.FetchCallerIdentity(ctx, req)
+
+			if tt.expectedErr != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedErr)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedCallerArn, caller.Arn)
+			}
+		})
+	}
+}

--- a/identity/identity.go
+++ b/identity/identity.go
@@ -13,6 +13,7 @@ type AllowAllValidator struct{}
 
 func (v *AllowAllValidator) ValidateIdentity(identity *CallerIdentity) error {
 	if identity == nil || identity.Arn == "" {
+		//nolint:goerr113
 		return errors.New("identity missing or invalid")
 	}
 	return nil

--- a/identity/identity.go
+++ b/identity/identity.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 )
 
-type IdentityValidator interface {
+type Validator interface {
 	ValidateIdentity(ctx context.Context, identity *CallerIdentity) error
 }
 

--- a/identity/identity.go
+++ b/identity/identity.go
@@ -2,6 +2,8 @@ package identity
 
 import (
 	"errors"
+
+	prbot "github.com/marqeta/pr-bot"
 )
 
 type Validator interface {
@@ -9,12 +11,22 @@ type Validator interface {
 }
 
 // Default validator: allows anything with a non-empty ARN
-type AllowAllValidator struct{}
+type AllowAllValidator struct {
+	Config *prbot.Config
+}
 
 func (v *AllowAllValidator) ValidateIdentity(identity *CallerIdentity) error {
-	if identity == nil || identity.Arn == "" {
-		//nolint:goerr113
+	if identity == nil || !stringInSlice(identity.Arn, v.Config.Identity.AllowedCallerArns) || !stringInSlice(identity.Account, v.Config.Identity.AllowedCallerAccounts) {
 		return errors.New("identity missing or invalid")
 	}
 	return nil
+}
+
+func stringInSlice(target string, list []string) bool {
+	for _, s := range list {
+		if s == target {
+			return true
+		}
+	}
+	return false
 }

--- a/identity/identity.go
+++ b/identity/identity.go
@@ -1,0 +1,20 @@
+package identity
+
+import (
+	"context"
+	"errors"
+)
+
+type IdentityValidator interface {
+	ValidateIdentity(ctx context.Context, identity *CallerIdentity) error
+}
+
+// Default validator: allows anything with a non-empty ARN
+type AllowAllValidator struct{}
+
+func (v *AllowAllValidator) ValidateIdentity(ctx context.Context, identity *CallerIdentity) error {
+	if identity == nil || identity.Arn == "" {
+		return errors.New("identity missing or invalid")
+	}
+	return nil
+}

--- a/identity/identity.go
+++ b/identity/identity.go
@@ -1,18 +1,17 @@
 package identity
 
 import (
-	"context"
 	"errors"
 )
 
 type Validator interface {
-	ValidateIdentity(ctx context.Context, identity *CallerIdentity) error
+	ValidateIdentity(identity *CallerIdentity) error
 }
 
 // Default validator: allows anything with a non-empty ARN
 type AllowAllValidator struct{}
 
-func (v *AllowAllValidator) ValidateIdentity(ctx context.Context, identity *CallerIdentity) error {
+func (v *AllowAllValidator) ValidateIdentity(identity *CallerIdentity) error {
 	if identity == nil || identity.Arn == "" {
 		return errors.New("identity missing or invalid")
 	}

--- a/identity/identity.go
+++ b/identity/identity.go
@@ -17,6 +17,7 @@ type AllowAllValidator struct {
 
 func (v *AllowAllValidator) ValidateIdentity(identity *CallerIdentity) error {
 	if identity == nil || !stringInSlice(identity.Arn, v.Config.Identity.AllowedCallerArns) || !stringInSlice(identity.Account, v.Config.Identity.AllowedCallerAccounts) {
+		//nolint:err113
 		return errors.New("identity missing or invalid")
 	}
 	return nil

--- a/identity/identity_test.go
+++ b/identity/identity_test.go
@@ -14,9 +14,9 @@ func TestAllowAllValidator_ValidateIdentity(t *testing.T) {
 	ctx := context.Background()
 
 	tests := []struct {
-		name     string
-		input    *identity.CallerIdentity
-		wantErr  error
+		name    string
+		input   *identity.CallerIdentity
+		wantErr error
 	}{
 		{
 			name:    "valid identity",

--- a/identity/identity_test.go
+++ b/identity/identity_test.go
@@ -71,6 +71,7 @@ func TestAllowAllValidator_ValidateIdentity(t *testing.T) {
 		{
 			name:    "invalid account",
 			input:   &identity.CallerIdentity{Arn: "arn:aws:iam::123456789012:role/MyRole", Account: "000000000000"},
+			//nolint:err113
 			wantErr: errors.New("identity missing or invalid"),
 		},
 	}

--- a/identity/identity_test.go
+++ b/identity/identity_test.go
@@ -1,0 +1,49 @@
+package identity_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/marqeta/pr-bot/identity"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAllowAllValidator_ValidateIdentity(t *testing.T) {
+	validator := &identity.AllowAllValidator{}
+	ctx := context.Background()
+
+	tests := []struct {
+		name     string
+		input    *identity.CallerIdentity
+		wantErr  error
+	}{
+		{
+			name:    "valid identity",
+			input:   &identity.CallerIdentity{Arn: "arn:aws:iam::123456789012:role/MyRole"},
+			wantErr: nil,
+		},
+		{
+			name:    "nil identity",
+			input:   nil,
+			wantErr: errors.New("identity missing or invalid"),
+		},
+		{
+			name:    "empty ARN",
+			input:   &identity.CallerIdentity{Arn: ""},
+			wantErr: errors.New("identity missing or invalid"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validator.ValidateIdentity(ctx, tt.input)
+			if tt.wantErr != nil {
+				assert.Error(t, err)
+				assert.EqualError(t, err, tt.wantErr.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/identity/identity_test.go
+++ b/identity/identity_test.go
@@ -1,7 +1,6 @@
 package identity_test
 
 import (
-	"context"
 	"errors"
 	"testing"
 
@@ -11,7 +10,6 @@ import (
 
 func TestAllowAllValidator_ValidateIdentity(t *testing.T) {
 	validator := &identity.AllowAllValidator{}
-	ctx := context.Background()
 
 	tests := []struct {
 		name    string
@@ -39,7 +37,7 @@ func TestAllowAllValidator_ValidateIdentity(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validator.ValidateIdentity(ctx, tt.input)
+			err := validator.ValidateIdentity(tt.input)
 			if tt.wantErr != nil {
 				assert.Error(t, err)
 				assert.EqualError(t, err, tt.wantErr.Error())

--- a/identity/identity_test.go
+++ b/identity/identity_test.go
@@ -24,13 +24,15 @@ func TestAllowAllValidator_ValidateIdentity(t *testing.T) {
 			wantErr: nil,
 		},
 		{
-			name:    "nil identity",
-			input:   nil,
+			name:  "nil identity",
+			input: nil,
+			//nolint:goerr113
 			wantErr: errors.New("identity missing or invalid"),
 		},
 		{
-			name:    "empty ARN",
-			input:   &identity.CallerIdentity{Arn: ""},
+			name:  "empty ARN",
+			input: &identity.CallerIdentity{Arn: ""},
+			//nolint:goerr113
 			wantErr: errors.New("identity missing or invalid"),
 		},
 	}

--- a/identity/identity_test.go
+++ b/identity/identity_test.go
@@ -1,15 +1,52 @@
 package identity_test
 
 import (
+	"context"
 	"errors"
 	"testing"
 
+	prbot "github.com/marqeta/pr-bot"
 	"github.com/marqeta/pr-bot/identity"
 	"github.com/stretchr/testify/assert"
 )
 
+// Wrap the validator to take a config
+type testValidator struct {
+	Config *prbot.Config
+}
+
+func (v *testValidator) ValidateIdentity(ctx context.Context, identity *identity.CallerIdentity) error {
+	if identity == nil ||
+		!stringInSlice(identity.Arn, v.Config.Identity.AllowedCallerArns) ||
+		!stringInSlice(identity.Account, v.Config.Identity.AllowedCallerAccounts) {
+		return errors.New("identity missing or invalid")
+	}
+	return nil
+}
+
+func stringInSlice(target string, list []string) bool {
+	for _, s := range list {
+		if s == target {
+			return true
+		}
+	}
+	return false
+}
+
 func TestAllowAllValidator_ValidateIdentity(t *testing.T) {
-	validator := &identity.AllowAllValidator{}
+	ctx := context.Background()
+
+	testConfig := &prbot.Config{
+		Identity: struct {
+			AllowedCallerArns     []string `yaml:"AllowedCallerArns" env:"ALLOWED_CALLER_ARNS"`
+			AllowedCallerAccounts []string `yaml:"AllowedCallerAccounts" env:"ALLOWED_CALLER_ACCOUNTS"`
+		}{
+			AllowedCallerArns:     []string{"arn:aws:iam::123456789012:role/MyRole"},
+			AllowedCallerAccounts: []string{"123456789012"},
+		},
+	}
+
+	validator := &testValidator{Config: testConfig}
 
 	tests := []struct {
 		name    string
@@ -18,26 +55,29 @@ func TestAllowAllValidator_ValidateIdentity(t *testing.T) {
 	}{
 		{
 			name:    "valid identity",
-			input:   &identity.CallerIdentity{Arn: "arn:aws:iam::123456789012:role/MyRole"},
+			input:   &identity.CallerIdentity{Arn: "arn:aws:iam::123456789012:role/MyRole", Account: "123456789012"},
 			wantErr: nil,
 		},
 		{
-			name:  "nil identity",
-			input: nil,
-			//nolint:goerr113
+			name:    "nil identity",
+			input:   nil,
 			wantErr: errors.New("identity missing or invalid"),
 		},
 		{
-			name:  "empty ARN",
-			input: &identity.CallerIdentity{Arn: ""},
-			//nolint:goerr113
+			name:    "invalid arn",
+			input:   &identity.CallerIdentity{Arn: "arn:aws:iam::000000000000:role/InvalidRole", Account: "123456789012"},
+			wantErr: errors.New("identity missing or invalid"),
+		},
+		{
+			name:    "invalid account",
+			input:   &identity.CallerIdentity{Arn: "arn:aws:iam::123456789012:role/MyRole", Account: "000000000000"},
 			wantErr: errors.New("identity missing or invalid"),
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validator.ValidateIdentity(tt.input)
+			err := validator.ValidateIdentity(ctx, tt.input)
 			if tt.wantErr != nil {
 				assert.Error(t, err)
 				assert.EqualError(t, err, tt.wantErr.Error())

--- a/identity/model.go
+++ b/identity/model.go
@@ -1,0 +1,13 @@
+package identity
+
+type CallerIdentity struct {
+	Arn     string `json:"Arn"`
+	Account string `json:"Account"`
+	UserID  string `json:"UserId"`
+}
+
+type GetCallerIdentityJSON struct {
+	GetCallerIdentityResponse struct {
+		GetCallerIdentityResult CallerIdentity `json:"GetCallerIdentityResult"`
+	} `json:"GetCallerIdentityResponse"`
+}

--- a/identity/verifier.go
+++ b/identity/verifier.go
@@ -1,0 +1,31 @@
+package identity
+
+import (
+	"context"
+	"net/http"
+
+	pe "github.com/marqeta/pr-bot/errors"
+)
+
+type IdentityVerifier interface {
+	Verify(ctx context.Context, r *http.Request) (string, error)
+}
+
+type STSVerifier struct {
+	HTTPClient *http.Client
+	Validator  IdentityValidator
+	Fetcher    IdentityFetcher
+}
+
+func (v *STSVerifier) Verify(ctx context.Context, r *http.Request) (string, error) {
+	identity, err := v.Fetcher.FetchCallerIdentity(ctx, r)
+	if err != nil {
+		return "", err
+	}
+
+	if err := v.Validator.ValidateIdentity(ctx, identity); err != nil {
+		return "", pe.UserError(ctx, "unauthorized identity", err)
+	}
+
+	return identity.Arn, nil
+}

--- a/identity/verifier.go
+++ b/identity/verifier.go
@@ -23,7 +23,7 @@ func (v *STSVerifier) Verify(ctx context.Context, r *http.Request) (string, erro
 		return "", err
 	}
 
-	if err := v.Validator.ValidateIdentity(ctx, identity); err != nil {
+	if err := v.Validator.ValidateIdentity(identity); err != nil {
 		return "", pe.UserError(ctx, "unauthorized identity", err)
 	}
 

--- a/identity/verifier.go
+++ b/identity/verifier.go
@@ -7,14 +7,14 @@ import (
 	pe "github.com/marqeta/pr-bot/errors"
 )
 
-type IdentityVerifier interface {
+type Verifier interface {
 	Verify(ctx context.Context, r *http.Request) (string, error)
 }
 
 type STSVerifier struct {
 	HTTPClient *http.Client
-	Validator  IdentityValidator
-	Fetcher    IdentityFetcher
+	Validator  Validator
+	Fetcher    Fetcher
 }
 
 func (v *STSVerifier) Verify(ctx context.Context, r *http.Request) (string, error) {

--- a/identity/verifier_test.go
+++ b/identity/verifier_test.go
@@ -15,7 +15,7 @@ type mockFetcher struct {
 	err      error
 }
 
-func (m *mockFetcher) FetchCallerIdentity(ctx context.Context, r *http.Request) (*identity.CallerIdentity, error) {
+func (m *mockFetcher) FetchCallerIdentity(_ context.Context, _ *http.Request) (*identity.CallerIdentity, error) {
 	return m.identity, m.err
 }
 
@@ -23,7 +23,7 @@ type mockValidator struct {
 	err error
 }
 
-func (m *mockValidator) ValidateIdentity(ctx context.Context, identity *identity.CallerIdentity) error {
+func (m *mockValidator) ValidateIdentity(_ context.Context, _ *identity.CallerIdentity) error {
 	return m.err
 }
 
@@ -43,6 +43,7 @@ func TestSTSVerifier_Verify(t *testing.T) {
 
 	t.Run("fetch error", func(t *testing.T) {
 		v := identity.STSVerifier{
+			//nolint:goerr113
 			Fetcher:   &mockFetcher{identity: nil, err: errors.New("fetch failed")},
 			Validator: &mockValidator{err: nil},
 		}
@@ -53,7 +54,8 @@ func TestSTSVerifier_Verify(t *testing.T) {
 
 	t.Run("validation error", func(t *testing.T) {
 		v := identity.STSVerifier{
-			Fetcher:   &mockFetcher{identity: &identity.CallerIdentity{Arn: "bad"}, err: nil},
+			Fetcher: &mockFetcher{identity: &identity.CallerIdentity{Arn: "bad"}, err: nil},
+			//nolint:goerr113
 			Validator: &mockValidator{err: errors.New("unauthorized")},
 		}
 		arn, err := v.Verify(ctx, req)

--- a/identity/verifier_test.go
+++ b/identity/verifier_test.go
@@ -1,0 +1,64 @@
+package identity_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/marqeta/pr-bot/identity"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockFetcher struct {
+	identity *identity.CallerIdentity
+	err      error
+}
+
+func (m *mockFetcher) FetchCallerIdentity(ctx context.Context, r *http.Request) (*identity.CallerIdentity, error) {
+	return m.identity, m.err
+}
+
+type mockValidator struct {
+	err error
+}
+
+func (m *mockValidator) ValidateIdentity(ctx context.Context, identity *identity.CallerIdentity) error {
+	return m.err
+}
+
+func TestSTSVerifier_Verify(t *testing.T) {
+	ctx := context.TODO()
+	req, _ := http.NewRequest("GET", "http://localhost", nil)
+
+	t.Run("valid identity", func(t *testing.T) {
+		v := identity.STSVerifier{
+			Fetcher: &mockFetcher{identity: &identity.CallerIdentity{Arn: "arn:aws:iam::abc"}, err: nil},
+			Validator: &mockValidator{err: nil},
+		}
+		arn, err := v.Verify(ctx, req)
+		assert.NoError(t, err)
+		assert.Equal(t, "arn:aws:iam::abc", arn)
+	})
+
+	t.Run("fetch error", func(t *testing.T) {
+		v := identity.STSVerifier{
+			Fetcher: &mockFetcher{identity: nil, err: errors.New("fetch failed")},
+			Validator: &mockValidator{err: nil},
+		}
+		arn, err := v.Verify(ctx, req)
+		assert.Error(t, err)
+		assert.Empty(t, arn)
+	})
+
+	t.Run("validation error", func(t *testing.T) {
+		v := identity.STSVerifier{
+			Fetcher: &mockFetcher{identity: &identity.CallerIdentity{Arn: "bad"}, err: nil},
+			Validator: &mockValidator{err: errors.New("unauthorized")},
+		}
+		arn, err := v.Verify(ctx, req)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "unauthorized identity")
+		assert.Empty(t, arn)
+	})
+}

--- a/identity/verifier_test.go
+++ b/identity/verifier_test.go
@@ -33,7 +33,7 @@ func TestSTSVerifier_Verify(t *testing.T) {
 
 	t.Run("valid identity", func(t *testing.T) {
 		v := identity.STSVerifier{
-			Fetcher: &mockFetcher{identity: &identity.CallerIdentity{Arn: "arn:aws:iam::abc"}, err: nil},
+			Fetcher:   &mockFetcher{identity: &identity.CallerIdentity{Arn: "arn:aws:iam::abc"}, err: nil},
 			Validator: &mockValidator{err: nil},
 		}
 		arn, err := v.Verify(ctx, req)
@@ -43,7 +43,7 @@ func TestSTSVerifier_Verify(t *testing.T) {
 
 	t.Run("fetch error", func(t *testing.T) {
 		v := identity.STSVerifier{
-			Fetcher: &mockFetcher{identity: nil, err: errors.New("fetch failed")},
+			Fetcher:   &mockFetcher{identity: nil, err: errors.New("fetch failed")},
 			Validator: &mockValidator{err: nil},
 		}
 		arn, err := v.Verify(ctx, req)
@@ -53,7 +53,7 @@ func TestSTSVerifier_Verify(t *testing.T) {
 
 	t.Run("validation error", func(t *testing.T) {
 		v := identity.STSVerifier{
-			Fetcher: &mockFetcher{identity: &identity.CallerIdentity{Arn: "bad"}, err: nil},
+			Fetcher:   &mockFetcher{identity: &identity.CallerIdentity{Arn: "bad"}, err: nil},
 			Validator: &mockValidator{err: errors.New("unauthorized")},
 		}
 		arn, err := v.Verify(ctx, req)

--- a/identity/verifier_test.go
+++ b/identity/verifier_test.go
@@ -23,7 +23,7 @@ type mockValidator struct {
 	err error
 }
 
-func (m *mockValidator) ValidateIdentity(_ context.Context, _ *identity.CallerIdentity) error {
+func (m *mockValidator) ValidateIdentity(_ *identity.CallerIdentity) error {
 	return m.err
 }
 


### PR DESCRIPTION
Making the data endpoint more secure by validating that the appropriate sigv4 signature is provided and verified. 