### PR TITLE
Add config to allow HTTP for non-local environments

### DIFF
--- a/config.go
+++ b/config.go
@@ -19,10 +19,10 @@ type Config struct {
 	ServiceName string `yaml:"ServiceName" env:"SERVICE_NAME" env-default:"pr-bot" env-description:"Name of the service"`
 	Env         string `yaml:"Env" env:"ENV" env-default:"local" env-description:"stage name; one of local|dev|staging|prod"`
 	Server      struct {
-		Host    string `yaml:"Host" env:"HOST" env-description:"Server host"`
-		Port    int    `yaml:"Port" env:"PORT" env-description:"Server port"`
-		useHTTP bool   `yaml:"UseHTTP" env:"USE_HTTP" env-default:"false" env-description:"Use HTTP"`
-		TLS     struct {
+		Host       string `yaml:"Host" env:"HOST" env-description:"Server host"`
+		Port       int    `yaml:"Port" env:"PORT" env-description:"Server port"`
+		disableTLS bool   `yaml:"DisableTLS" env:"DISABLE_TLS" env-default:"false" env-description:"Disable TLS"`
+		TLS        struct {
 			CertFile string `yaml:"CertFile" env:"CERT_FILE" env-description:"Server certificate file path"`
 			KeyFile  string `yaml:"KeyFile" env:"KEY_FILE" env-description:"File path of server cert's private key"`
 		} `yaml:"TLS" env-prefix:"TLS_"`

--- a/config.go
+++ b/config.go
@@ -21,7 +21,7 @@ type Config struct {
 	Server      struct {
 		Host       string `yaml:"Host" env:"HOST" env-description:"Server host"`
 		Port       int    `yaml:"Port" env:"PORT" env-description:"Server port"`
-		disableTLS bool   `yaml:"DisableTLS" env:"DISABLE_TLS" env-default:"false" env-description:"Disable TLS"`
+		DisableTLS bool   `yaml:"DisableTLS" env:"DISABLE_TLS" env-default:"false" env-description:"Disable TLS"`
 		TLS        struct {
 			CertFile string `yaml:"CertFile" env:"CERT_FILE" env-description:"Server certificate file path"`
 			KeyFile  string `yaml:"KeyFile" env:"KEY_FILE" env-description:"File path of server cert's private key"`

--- a/config.go
+++ b/config.go
@@ -19,9 +19,10 @@ type Config struct {
 	ServiceName string `yaml:"ServiceName" env:"SERVICE_NAME" env-default:"pr-bot" env-description:"Name of the service"`
 	Env         string `yaml:"Env" env:"ENV" env-default:"local" env-description:"stage name; one of local|dev|staging|prod"`
 	Server      struct {
-		Host string `yaml:"Host" env:"HOST" env-description:"Server host"`
-		Port int    `yaml:"Port" env:"PORT" env-description:"Server port"`
-		TLS  struct {
+		Host    string `yaml:"Host" env:"HOST" env-description:"Server host"`
+		Port    int    `yaml:"Port" env:"PORT" env-description:"Server port"`
+		useHTTP bool   `yaml:"UseHTTP" env:"USE_HTTP" env-default:"false" env-description:"Use HTTP"`
+		TLS     struct {
 			CertFile string `yaml:"CertFile" env:"CERT_FILE" env-description:"Server certificate file path"`
 			KeyFile  string `yaml:"KeyFile" env:"KEY_FILE" env-description:"File path of server cert's private key"`
 		} `yaml:"TLS" env-prefix:"TLS_"`

--- a/config/local.yaml
+++ b/config/local.yaml
@@ -3,6 +3,7 @@ Env: local
 Server:
   Host: localhost
   Port: 9090
+  DisableTLS: true
 GHE:
   Hostname: github-qa.marqeta.com
 ConfigStore:

--- a/server.go
+++ b/server.go
@@ -36,7 +36,7 @@ func NewServer(cfg *Config, routes http.Handler) *Server {
 }
 
 func (srv *Server) Start() {
-	if srv.config.Env == "local" {
+	if srv.config.Env == "local" || srv.config.Server.useHTTP {
 		srv.startHTTP()
 	} else {
 		srv.startHTTPS()

--- a/server.go
+++ b/server.go
@@ -36,7 +36,7 @@ func NewServer(cfg *Config, routes http.Handler) *Server {
 }
 
 func (srv *Server) Start() {
-	if srv.config.Server.disableTLS {
+	if srv.config.Server.DisableTLS {
 		srv.startHTTP()
 	} else {
 		srv.startHTTPS()

--- a/server.go
+++ b/server.go
@@ -36,7 +36,7 @@ func NewServer(cfg *Config, routes http.Handler) *Server {
 }
 
 func (srv *Server) Start() {
-	if srv.config.Env == "local" || srv.config.Server.useHTTP {
+	if srv.config.Server.disableTLS {
 		srv.startHTTP()
 	} else {
 		srv.startHTTPS()


### PR DESCRIPTION
## Summary
Add `useHTTP` configuration option to enable HTTP server mode for non-local deployments

## Changes
- Added new boolean config variable `DisableTLS` to allow the server to run on HTTP instead of HTTPS
- This enables deployments in environments where TLS termination is handled upstream (e.g., load balancers, reverse proxies, or container orchestration platforms)

## Motivation
Currently, the pr-bot server requires HTTPS/TLS configuration, which creates deployment challenges in environments where:
- TLS certificates are managed by external infrastructure (load balancers, ingress controllers)
- The application runs behind a reverse proxy that handles SSL termination
- Container orchestration platforms manage certificate provisioning

## Usage
Set `DisableTLS: true` in the configuration to run the server on HTTP. The default remains HTTPS for security.

## Security Considerations
This option should only be used when TLS is terminated upstream. Direct HTTP exposure to the internet is not recommended.
